### PR TITLE
Add try_get() method, reduce heap allocations, returns nullptr on get() timeout

### DIFF
--- a/Msg.hpp
+++ b/Msg.hpp
@@ -1,6 +1,4 @@
-#ifndef POLYM_MSG_HPP
-#define POLYM_MSG_HPP
-
+#pragma once
 #include <memory>
 #include <utility>
 
@@ -98,5 +96,3 @@ private:
 };
 
 }
-
-#endif

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -1,6 +1,4 @@
-#ifndef POLYM_QUEUE_HPP
-#define POLYM_QUEUE_HPP
-
+#pragma once
 #include "Msg.hpp"
 #include <memory>
 
@@ -67,5 +65,3 @@ private:
 };
 
 }
-
-#endif

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -6,9 +6,6 @@
 
 namespace PolyM {
 
-/** Msg ID for timeout message */
-const int MSG_TIMEOUT = -1;
-
 /**
  * Queue is a thread-safe message queue.
  * It supports one-way messaging and request-response pattern.
@@ -36,6 +33,12 @@ public:
      *                      0 = wait indefinitely.
      */
     std::unique_ptr<Msg> get(int timeoutMillis = 0);
+
+    /**
+    * Get message from the head of the queue. Returns an empty pointer if no 
+    * message is available.
+    */
+    std::unique_ptr<Msg> tryGet();
 
     /**
      * Make a request.

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -52,12 +52,13 @@ public:
 
     /**
      * Respond to a request previously made with request().
-     *
+     * If the requestID has been found, return true.
+     * 
      * @param reqUid Msg UID of the request message.
      * @param responseMsg Response message. The requester will receive it as the return value of
      *                    request().
      */
-    void respondTo(MsgUID reqUid, Msg&& responseMsg);
+    bool respondTo(MsgUID reqUid, Msg&& responseMsg);
 
 private:
     class Impl;

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -27,7 +27,7 @@ public:
     /**
      * Get message from the head of the queue.
      * Blocks until at least one message is available in the queue, or until timeout happens.
-     * If get() returns due to timeout, the returned Msg will have Msg ID MSG_TIMEOUT.
+     * If get() returns due to timeout, returns a nullptr.
      *
      * @param timeoutMillis How many ms to wait for message until timeout happens.
      *                      0 = wait indefinitely.
@@ -35,15 +35,16 @@ public:
     std::unique_ptr<Msg> get(int timeoutMillis = 0);
 
     /**
-    * Get message from the head of the queue. Returns an empty pointer if no 
-    * message is available.
+    * Get message from the head of the queue.
+    * Returns an empty pointer if no message is available.
     */
     std::unique_ptr<Msg> tryGet();
 
     /**
      * Make a request.
      * Call will block until response is given with respondTo().
-     *
+     * If request() returns due to timeout, returns a nullptr.
+     * 
      * @param msg Request message. Is put to the queue so it can be retrieved from it with get().
      * @param timeoutMillis How many ms to wait for response until timeout happens.
      *                      0 = wait indefinitely.

--- a/Queue.hpp
+++ b/Queue.hpp
@@ -45,8 +45,10 @@ public:
      * Call will block until response is given with respondTo().
      *
      * @param msg Request message. Is put to the queue so it can be retrieved from it with get().
+     * @param timeoutMillis How many ms to wait for response until timeout happens.
+     *                      0 = wait indefinitely.
      */
-    std::unique_ptr<Msg> request(Msg&& msg);
+    std::unique_ptr<Msg> request(Msg&& msg, int timeoutMillis = 0);
 
     /**
      * Respond to a request previously made with request().

--- a/Test.cpp
+++ b/Test.cpp
@@ -142,9 +142,23 @@ void testReceiveTimeout()
     end = std::chrono::steady_clock::now();
     dur = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-    TEST_EQUALS(m2->getMsgId(), PolyM::MSG_TIMEOUT);
+    TEST_EQUALS(m2.get(), (PolyM::Msg*) nullptr);
     //TEST_LESS_THAN(5LL, dur);
     //TEST_LESS_THAN(dur, 15LL);
+}
+
+// Test tryGet() method
+void testTryGet()
+{
+    PolyM::Queue q;
+
+    auto m1 = q.tryGet();
+    TEST_EQUALS(m1.get(), (PolyM::Msg*) nullptr);
+
+    q.put(PolyM::Msg(1));
+
+    auto m2 = q.tryGet();
+    TEST_NOT_EQUALS(m2.get(), (PolyM::Msg*) nullptr);
 }
 
 // Test 2-to-1 request-response scenario
@@ -201,6 +215,7 @@ int main()
     tester.addTest(test2To1MsgOrder, "Test 2-to-1 message order");
     tester.addTest(testDataMsg, "Test DataMsg");
     tester.addTest(testReceiveTimeout, "Test receive timeout");
+    tester.addTest(testTryGet, "Test tryGet");
     tester.addTest(testRequestResponse, "Test 2-to-1 request-response");
     tester.runTests();
 }

--- a/Test.cpp
+++ b/Test.cpp
@@ -201,6 +201,16 @@ void testRequestResponse()
     t3.join();
 }
 
+void testRequestExpired()
+{
+    PolyM::Queue queue;
+    auto m1 = queue.request(PolyM::Msg(42), 50);
+    TEST_EQUALS(m1.get(), (PolyM::Msg*) nullptr);
+
+    auto m2 = queue.get();
+    TEST_EQUALS(m2->getMsgId(), 42);
+}
+
 int main()
 {
     // Statically assert that messages can't be copied or moved
@@ -217,5 +227,6 @@ int main()
     tester.addTest(testReceiveTimeout, "Test receive timeout");
     tester.addTest(testTryGet, "Test tryGet");
     tester.addTest(testRequestResponse, "Test 2-to-1 request-response");
+    tester.addTest(testRequestExpired, "Test request() timeout");
     tester.runTests();
 }

--- a/Tester.hpp
+++ b/Tester.hpp
@@ -1,5 +1,4 @@
-#ifndef TESTER_HPP
-#define TESTER_HPP
+#pragma once
 
 #include <cstdlib>
 #include <iostream>
@@ -113,5 +112,3 @@ private:
     std::string name_;
     std::vector<std::pair<std::function<void()>, std::string>> tests_;
 };
-
-#endif


### PR DESCRIPTION
As stated in #6, this PR brings some performances improvements and reduces allocation on the heap.